### PR TITLE
emit messaging_token_received signal on token refresh

### DIFF
--- a/source/android/firebase_messaging/src/main/java/com/godotx/firebase/messaging/FirebaseMessagingPlugin.kt
+++ b/source/android/firebase_messaging/src/main/java/com/godotx/firebase/messaging/FirebaseMessagingPlugin.kt
@@ -146,6 +146,7 @@ class FirebaseMessagingPlugin(godot: Godot) : GodotPlugin(godot) {
             coldStartIntent?.let { handleIntentMessage(it) }
             coldStartIntent = null
             deferredToken?.let { notifyNewToken(it) }
+            deferredToken = null
         } catch (e: Exception) {
             Log.e(TAG, "Firebase initialization check failed", e)
             emitSignal("messaging_error", e.message ?: "firebase_check_failed")

--- a/source/android/firebase_messaging/src/main/java/com/godotx/firebase/messaging/FirebaseMessagingPlugin.kt
+++ b/source/android/firebase_messaging/src/main/java/com/godotx/firebase/messaging/FirebaseMessagingPlugin.kt
@@ -30,6 +30,7 @@ class FirebaseMessagingPlugin(godot: Godot) : GodotPlugin(godot) {
 
     private val handledMessageIds = mutableSetOf<String>()
     private var coldStartIntent: Intent? = null
+    private var deferredToken: String? = null
     private var isInitialized = false
 
     override fun getPluginName(): String {
@@ -44,6 +45,14 @@ class FirebaseMessagingPlugin(godot: Godot) : GodotPlugin(godot) {
         val title = remoteMessage.notification?.title ?: ""
         val body = remoteMessage.notification?.body ?: ""
         emitSignal("messaging_message_received", title, body)
+    }
+
+    fun notifyNewToken(token: String) {
+        if (!isInitialized) {
+            deferredToken = token
+            return
+        }
+        emitSignal("messaging_token_received", token)
     }
 
     private fun handleIntentMessage(intent: Intent) {
@@ -136,6 +145,7 @@ class FirebaseMessagingPlugin(godot: Godot) : GodotPlugin(godot) {
             // Emit any notification that was received before initialization (cold start or early resume)
             coldStartIntent?.let { handleIntentMessage(it) }
             coldStartIntent = null
+            deferredToken?.let { notifyNewToken(it) }
         } catch (e: Exception) {
             Log.e(TAG, "Firebase initialization check failed", e)
             emitSignal("messaging_error", e.message ?: "firebase_check_failed")

--- a/source/android/firebase_messaging/src/main/java/com/godotx/firebase/messaging/GodotxFirebaseMessagingService.kt
+++ b/source/android/firebase_messaging/src/main/java/com/godotx/firebase/messaging/GodotxFirebaseMessagingService.kt
@@ -30,6 +30,7 @@ class GodotxFirebaseMessagingService : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         Log.d(TAG, "New FCM token: $token")
+        FirebaseMessagingPlugin.instance?.notifyNewToken(token)
     }
 }
 


### PR DESCRIPTION
## Fix: Android `messaging_token_received` signal not emitted on token refresh

This PR fixes an issue where the `messaging_token_received` signal was not being emitted on Android when the FCM token was refreshed.

### Problem

`GodotxFirebaseMessagingService.onNewToken` was receiving the refreshed token but was not forwarding it to `FirebaseMessagingPlugin`, so the `messaging_token_received` signal was not fired in Godot.

### Changes

#### `FirebaseMessagingPlugin.kt`
- Added `notifyNewToken(token: String)` — emits the `messaging_token_received` signal with the new token.
- If `notifyNewToken` is called before the plugin has finished initializing, the token is saved in `deferredToken` and replayed once initialization completes.

#### `GodotxFirebaseMessagingService.kt`
- In `onNewToken`, added a call to `FirebaseMessagingPlugin.instance?.notifyNewToken(token)` to forward the token to the plugin via the existing `WeakReference` singleton.

### Testing

Confirmed that `messaging_token_received` is emitted after the messaging module finishes initializing on app launch